### PR TITLE
Port OCaml utils to Rust

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,3 +6,4 @@ pub mod token_stream;
 pub mod tokens;
 pub mod type_table;
 pub mod types;
+pub mod utils;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,54 @@
+pub mod list_util {
+    use std::cmp::Ordering;
+
+    pub fn max_by<T, F>(cmp: F, l: &[T]) -> Option<&T>
+    where
+        F: Fn(&T, &T) -> Ordering,
+    {
+        l.iter().max_by(|a, b| cmp(a, b))
+    }
+
+    pub fn min_by<T, F>(cmp: F, l: &[T]) -> Option<&T>
+    where
+        F: Fn(&T, &T) -> Ordering,
+    {
+        l.iter().min_by(|a, b| cmp(a, b))
+    }
+
+    pub fn make_list<T: Clone>(len: usize, v: T) -> Vec<T> {
+        vec![v; len]
+    }
+
+    pub fn last<T>(l: &[T]) -> Option<&T> {
+        l.last()
+    }
+
+    pub fn take<T: Clone>(n: usize, l: &[T]) -> Vec<T> {
+        l.iter().take(n).cloned().collect()
+    }
+
+    pub fn take_drop<T: Clone>(n: usize, l: &[T]) -> (Vec<T>, Vec<T>) {
+        let split = n.min(l.len());
+        let (left, right) = l.split_at(split);
+        (left.to_vec(), right.to_vec())
+    }
+}
+
+pub mod string_util {
+    pub fn drop(n: usize, s: &str) -> String {
+        s.chars().skip(n).collect()
+    }
+
+    pub fn chop_suffix(s: &str, n: usize) -> String {
+        let len = s.chars().count();
+        s.chars().take(len.saturating_sub(n)).collect()
+    }
+
+    pub fn of_list(l: &[char]) -> String {
+        l.iter().collect()
+    }
+
+    pub fn is_alnum(c: char) -> bool {
+        c.is_ascii_alphanumeric()
+    }
+}

--- a/rust/tests/test_utils.rs
+++ b/rust/tests/test_utils.rs
@@ -1,0 +1,21 @@
+use nqcc_rust::utils::{list_util, string_util};
+
+#[test]
+fn test_list_utils() {
+    let l = vec![3, 1, 4, 1, 5];
+    assert_eq!(list_util::max_by(|a, b| a.cmp(b), &l), Some(&5));
+    assert_eq!(list_util::min_by(|a, b| a.cmp(b), &l), Some(&1));
+    assert_eq!(list_util::make_list(3, 7), vec![7, 7, 7]);
+    assert_eq!(list_util::last(&l), Some(&5));
+    assert_eq!(list_util::take(3, &l), vec![3, 1, 4]);
+    assert_eq!(list_util::take_drop(3, &l), (vec![3, 1, 4], vec![1, 5]));
+}
+
+#[test]
+fn test_string_utils() {
+    assert_eq!(string_util::drop(2, "abcdef"), "cdef");
+    assert_eq!(string_util::chop_suffix("abcdef", 2), "abcd");
+    assert_eq!(string_util::of_list(&['a', 'b', 'c']), "abc");
+    assert!(string_util::is_alnum('a'));
+    assert!(!string_util::is_alnum('!'));
+}


### PR DESCRIPTION
## Summary
- add ListUtil and StringUtil in Rust with helpers for lists and strings
- expose new utils module
- test list and string utilities

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896f57db644832091efb362b55293ac