### PR TITLE
Port remaining util modules to Rust

### DIFF
--- a/rust/src/ast.rs
+++ b/rust/src/ast.rs
@@ -13,3 +13,13 @@ pub enum Statement {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program;
+
+pub mod typed {
+    use crate::types::Type;
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Exp<T> {
+        pub e: T,
+        pub t: Type,
+    }
+}

--- a/rust/src/disjoint_sets.rs
+++ b/rust/src/disjoint_sets.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[derive(Debug, Clone)]
+pub struct DisjointSets<T: Eq + Hash + Clone> {
+    parent: HashMap<T, T>,
+}
+
+impl<T: Eq + Hash + Clone> DisjointSets<T> {
+    pub fn new() -> Self {
+        Self { parent: HashMap::new() }
+    }
+
+    pub fn union(&mut self, x: T, y: T) {
+        self.parent.insert(x, y);
+    }
+
+    pub fn find(&self, x: &T) -> T {
+        match self.parent.get(x) {
+            Some(mapped_to) => self.find(mapped_to),
+            None => x.clone(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.parent.is_empty()
+    }
+}

--- a/rust/src/int8.rs
+++ b/rust/src/int8.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Int8(pub i8);
+
+impl Int8 {
+    pub const ZERO: Int8 = Int8(0);
+
+    pub fn of_int(i: i32) -> Self {
+        Int8(i as i8)
+    }
+
+    pub fn to_int(self) -> i32 {
+        self.0 as i32
+    }
+
+    pub fn of_int64(i: i64) -> Self {
+        Int8(i as i8)
+    }
+
+    pub fn to_int64(self) -> i64 {
+        self.0 as i64
+    }
+
+    pub fn to_string(self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl fmt::Display for Int8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+pub fn show(i: Int8) -> String {
+    i.to_string()
+}
+
+pub fn pp(f: &mut fmt::Formatter<'_>, i: &Int8) -> fmt::Result {
+    write!(f, "{}", i.0)
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,3 +7,8 @@ pub mod tokens;
 pub mod type_table;
 pub mod types;
 pub mod utils;
+pub mod disjoint_sets;
+pub mod int8;
+pub mod rounding;
+pub mod type_utils;
+pub mod unique_ids;

--- a/rust/src/rounding.rs
+++ b/rust/src/rounding.rs
@@ -1,0 +1,9 @@
+pub fn round_away_from_zero(n: i32, x: i32) -> i32 {
+    if x % n == 0 {
+        x
+    } else if x < 0 {
+        x - n - (x % n)
+    } else {
+        x + n - (x % n)
+    }
+}

--- a/rust/src/type_utils.rs
+++ b/rust/src/type_utils.rs
@@ -1,0 +1,119 @@
+use crate::ast::typed::Exp as TypedExp;
+use crate::type_table;
+use crate::types::Type;
+
+pub fn get_type<T>(exp: &TypedExp<T>) -> Type {
+    exp.t.clone()
+}
+
+pub fn set_type<T>(e: T, new_type: Type) -> TypedExp<T> {
+    TypedExp { e, t: new_type }
+}
+
+pub fn get_size(t: &Type) -> usize {
+    match t {
+        Type::Char | Type::SChar | Type::UChar => 1,
+        Type::Int | Type::UInt => 4,
+        Type::Long | Type::ULong | Type::Double | Type::Pointer(_) => 8,
+        Type::Array { elem_type, size } => size * get_size(elem_type),
+        Type::Structure(tag) => type_table::find(tag).size,
+        Type::FunType { .. } | Type::Void => {
+            panic!("Internal error: type doesn't have size: {}", t)
+        }
+    }
+}
+
+pub fn get_alignment(t: &Type) -> usize {
+    match t {
+        Type::Char | Type::SChar | Type::UChar => 1,
+        Type::Int | Type::UInt => 4,
+        Type::Long | Type::ULong | Type::Double | Type::Pointer(_) => 8,
+        Type::Array { elem_type, .. } => get_alignment(elem_type),
+        Type::Structure(tag) => type_table::find(tag).alignment,
+        Type::FunType { .. } | Type::Void => {
+            panic!("Internal error: type doesn't have alignment: {}", t)
+        }
+    }
+}
+
+pub fn is_signed(t: &Type) -> bool {
+    match t {
+        Type::Int | Type::Long | Type::Char | Type::SChar => true,
+        Type::UInt | Type::ULong | Type::Pointer(_) | Type::UChar => false,
+        Type::Double | Type::FunType { .. } | Type::Array { .. } | Type::Void | Type::Structure(_) => {
+            panic!(
+                "Internal error: signedness doesn't make sense for non-integral type {}",
+                t
+            )
+        }
+    }
+}
+
+pub fn is_pointer(t: &Type) -> bool {
+    matches!(t, Type::Pointer(_))
+}
+
+pub fn is_integer(t: &Type) -> bool {
+    matches!(
+        t,
+        Type::Char
+            | Type::UChar
+            | Type::SChar
+            | Type::Int
+            | Type::UInt
+            | Type::Long
+            | Type::ULong
+    )
+}
+
+pub fn is_array(t: &Type) -> bool {
+    matches!(t, Type::Array { .. })
+}
+
+pub fn is_character(t: &Type) -> bool {
+    matches!(t, Type::Char | Type::SChar | Type::UChar)
+}
+
+pub fn is_arithmetic(t: &Type) -> bool {
+    matches!(
+        t,
+        Type::Int
+            | Type::UInt
+            | Type::Long
+            | Type::ULong
+            | Type::Char
+            | Type::UChar
+            | Type::SChar
+            | Type::Double
+    )
+}
+
+pub fn is_scalar(t: &Type) -> bool {
+    match t {
+        Type::Array { .. } | Type::Void | Type::FunType { .. } | Type::Structure(_) => false,
+        Type::Int
+        | Type::UInt
+        | Type::Long
+        | Type::ULong
+        | Type::Char
+        | Type::UChar
+        | Type::SChar
+        | Type::Double
+        | Type::Pointer(_) => true,
+    }
+}
+
+pub fn is_complete(t: &Type) -> bool {
+    match t {
+        Type::Void => false,
+        Type::Structure(tag) => type_table::mem(tag),
+        _ => true,
+    }
+}
+
+pub fn is_complete_pointer(t: &Type) -> bool {
+    match t {
+        Type::Pointer(inner) => is_complete(inner),
+        _ => false,
+    }
+}

--- a/rust/src/unique_ids.rs
+++ b/rust/src/unique_ids.rs
@@ -1,0 +1,17 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+pub fn make_temporary() -> String {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("tmp.{}", n)
+}
+
+pub fn make_label(prefix: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("{}.{}", prefix, n)
+}
+
+pub fn make_named_temporary(prefix: &str) -> String {
+    make_label(prefix)
+}

--- a/rust/tests/test_utils.rs
+++ b/rust/tests/test_utils.rs
@@ -1,3 +1,9 @@
+use nqcc_rust::disjoint_sets::DisjointSets;
+use nqcc_rust::int8::Int8;
+use nqcc_rust::rounding;
+use nqcc_rust::type_utils;
+use nqcc_rust::types::Type;
+use nqcc_rust::unique_ids;
 use nqcc_rust::utils::{list_util, string_util};
 
 #[test]
@@ -18,4 +24,64 @@ fn test_string_utils() {
     assert_eq!(string_util::of_list(&['a', 'b', 'c']), "abc");
     assert!(string_util::is_alnum('a'));
     assert!(!string_util::is_alnum('!'));
+}
+
+#[test]
+fn test_int8() {
+    let i8 = Int8::of_int(100);
+    assert_eq!(i8.to_string(), "100");
+    let i8 = Int8::of_int(128);
+    assert_eq!(i8.to_string(), "-128");
+    let i8 = Int8::of_int64(-110);
+    assert_eq!(i8.to_string(), "-110");
+    let i8 = Int8::of_int64(1239235325);
+    assert_eq!(i8.to_string(), "-3");
+    let twelve = Int8::of_int(268);
+    let fourteen = Int8::of_int(-4082);
+    assert!(twelve < fourteen);
+}
+
+#[test]
+fn test_rounding() {
+    assert_eq!(rounding::round_away_from_zero(4, 8), 8);
+    assert_eq!(rounding::round_away_from_zero(4, 7), 8);
+    assert_eq!(rounding::round_away_from_zero(4, -7), -8);
+}
+
+#[test]
+fn test_unique_ids() {
+    let id1 = unique_ids::make_temporary();
+    let id2 = unique_ids::make_label("L");
+    let id3 = unique_ids::make_named_temporary("tmp");
+    assert!(id1.starts_with("tmp."));
+    assert!(id2.starts_with("L."));
+    assert!(id3.starts_with("tmp."));
+    assert_ne!(id1, id2);
+    assert_ne!(id2, id3);
+}
+
+#[test]
+fn test_disjoint_sets() {
+    let mut ds = DisjointSets::new();
+    assert!(ds.is_empty());
+    ds.union(1, 2);
+    assert!(!ds.is_empty());
+    ds.union(2, 3);
+    assert_eq!(ds.find(&1), 3);
+}
+
+#[test]
+fn test_type_utils() {
+    use Type::*;
+    assert_eq!(type_utils::get_size(&Int), 4);
+    assert_eq!(type_utils::get_alignment(&Double), 8);
+    assert!(type_utils::is_signed(&Int));
+    assert!(type_utils::is_pointer(&Pointer(Box::new(Int))));
+    assert!(type_utils::is_integer(&ULong));
+    assert!(type_utils::is_arithmetic(&Double));
+    assert!(type_utils::is_array(&Array { elem_type: Box::new(Char), size: 3 }));
+    assert!(type_utils::is_character(&SChar));
+    assert!(type_utils::is_scalar(&Pointer(Box::new(Int))));
+    assert!(!type_utils::is_complete(&Void));
+    assert!(type_utils::is_complete_pointer(&Pointer(Box::new(Int))));
 }


### PR DESCRIPTION
## Summary
- Add Rust equivalents for disjoint sets, Int8 type, rounding helpers, type utilities, and unique ID generation
- Extend AST with a generic typed expression container
- Cover new utilities with unit tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896f7097c008320a4634e6e4738ce0c