### PR TITLE
Port tacky, initializers, and symbols modules to Rust

### DIFF
--- a/rust/src/consts.rs
+++ b/rust/src/consts.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use crate::types::Type;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Const {
@@ -22,5 +23,17 @@ impl fmt::Display for Const {
             Const::ULong(u) => write!(f, "{}UL", u),
             Const::Double(d) => write!(f, "{}", d),
         }
+    }
+}
+
+pub fn type_of_const(c: &Const) -> Type {
+    match c {
+        Const::Char(_) => Type::SChar,
+        Const::UChar(_) => Type::UChar,
+        Const::Int(_) => Type::Int,
+        Const::Long(_) => Type::Long,
+        Const::UInt(_) => Type::UInt,
+        Const::ULong(_) => Type::ULong,
+        Const::Double(_) => Type::Double,
     }
 }

--- a/rust/src/initializers.rs
+++ b/rust/src/initializers.rs
@@ -1,0 +1,39 @@
+use crate::types::Type;
+use crate::type_utils;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StaticInit {
+    CharInit(i8),
+    UCharInit(u8),
+    IntInit(i32),
+    LongInit(i64),
+    UIntInit(u32),
+    ULongInit(u64),
+    DoubleInit(f64),
+    // zero out arbitrary number of bytes
+    ZeroInit(usize),
+    // flag indicates whether the string is null terminated
+    StringInit(String, bool),
+    // pointer to static variable
+    PointerInit(String),
+}
+
+pub fn zero(t: &Type) -> Vec<StaticInit> {
+    vec![StaticInit::ZeroInit(type_utils::get_size(t))]
+}
+
+pub fn is_zero(init: &StaticInit) -> bool {
+    match init {
+        StaticInit::CharInit(c) => *c == 0,
+        StaticInit::IntInit(i) => *i == 0,
+        StaticInit::LongInit(l) => *l == 0,
+        StaticInit::UCharInit(c) => *c == 0,
+        StaticInit::UIntInit(u) => *u == 0,
+        StaticInit::ULongInit(u) => *u == 0,
+        // NOTE: consider all doubles non-zero since we don't know
+        // if it's zero or negative zero
+        StaticInit::DoubleInit(_) => false,
+        StaticInit::ZeroInit(_) => true,
+        StaticInit::PointerInit(_) | StaticInit::StringInit(_, _) => false,
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,3 +12,6 @@ pub mod int8;
 pub mod rounding;
 pub mod type_utils;
 pub mod unique_ids;
+pub mod initializers;
+pub mod symbols;
+pub mod tacky;

--- a/rust/src/symbols.rs
+++ b/rust/src/symbols.rs
@@ -1,0 +1,97 @@
+use crate::initializers::StaticInit;
+use crate::types::Type;
+use crate::unique_ids;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum InitialValue {
+    Tentative,
+    Initial(Vec<StaticInit>),
+    NoInitializer,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IdentifierAttrs {
+    FunAttr { defined: bool, global: bool },
+    StaticAttr { init: InitialValue, global: bool },
+    ConstAttr(StaticInit),
+    LocalAttr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Entry {
+    pub t: Type,
+    pub attrs: IdentifierAttrs,
+}
+
+static SYMBOL_TABLE: Lazy<Mutex<HashMap<String, Entry>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn add_automatic_var(name: String, t: Type) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        name,
+        Entry { t, attrs: IdentifierAttrs::LocalAttr },
+    );
+}
+
+pub fn add_static_var(name: String, t: Type, global: bool, init: InitialValue) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        name,
+        Entry { t, attrs: IdentifierAttrs::StaticAttr { init, global } },
+    );
+}
+
+pub fn add_fun(name: String, t: Type, global: bool, defined: bool) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        name,
+        Entry { t, attrs: IdentifierAttrs::FunAttr { global, defined } },
+    );
+}
+
+pub fn get(name: &str) -> Entry {
+    SYMBOL_TABLE
+        .lock()
+        .unwrap()
+        .get(name)
+        .cloned()
+        .expect("symbol not found")
+}
+
+pub fn get_opt(name: &str) -> Option<Entry> {
+    SYMBOL_TABLE.lock().unwrap().get(name).cloned()
+}
+
+pub fn add_string(s: &str) -> String {
+    let str_id = unique_ids::make_named_temporary("string");
+    let t = Type::Array { elem_type: Box::new(Type::Char), size: s.len() + 1 };
+    SYMBOL_TABLE.lock().unwrap().insert(
+        str_id.clone(),
+        Entry { t, attrs: IdentifierAttrs::ConstAttr(StaticInit::StringInit(s.into(), true)) },
+    );
+    str_id
+}
+
+pub fn is_global(name: &str) -> bool {
+    match &get(name).attrs {
+        IdentifierAttrs::LocalAttr | IdentifierAttrs::ConstAttr(_) => false,
+        IdentifierAttrs::StaticAttr { global, .. } => *global,
+        IdentifierAttrs::FunAttr { global, .. } => *global,
+    }
+}
+
+pub fn bindings() -> Vec<(String, Entry)> {
+    SYMBOL_TABLE
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
+}
+
+pub fn iter<F: FnMut(&String, &Entry)>(mut f: F) {
+    for (k, v) in SYMBOL_TABLE.lock().unwrap().iter() {
+        f(k, v);
+    }
+}

--- a/rust/src/tacky.rs
+++ b/rust/src/tacky.rs
@@ -1,0 +1,75 @@
+use crate::consts::{self, Const};
+use crate::initializers::StaticInit;
+use crate::symbols;
+use crate::types::Type;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnaryOperator {
+    Complement,
+    Negate,
+    Not,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinaryOperator {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Mod,
+    Equal,
+    NotEqual,
+    LessThan,
+    LessOrEqual,
+    GreaterThan,
+    GreaterOrEqual,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TackyVal {
+    Constant(Const),
+    Var(String),
+}
+
+pub fn type_of_val(v: &TackyVal) -> Type {
+    match v {
+        TackyVal::Constant(c) => consts::type_of_const(c),
+        TackyVal::Var(name) => symbols::get(name).t,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Instruction {
+    Return(Option<TackyVal>),
+    SignExtend { src: TackyVal, dst: TackyVal },
+    ZeroExtend { src: TackyVal, dst: TackyVal },
+    DoubleToInt { src: TackyVal, dst: TackyVal },
+    IntToDouble { src: TackyVal, dst: TackyVal },
+    DoubleToUInt { src: TackyVal, dst: TackyVal },
+    UIntToDouble { src: TackyVal, dst: TackyVal },
+    Truncate { src: TackyVal, dst: TackyVal },
+    Unary { op: UnaryOperator, src: TackyVal, dst: TackyVal },
+    Binary { op: BinaryOperator, src1: TackyVal, src2: TackyVal, dst: TackyVal },
+    Copy { src: TackyVal, dst: TackyVal },
+    GetAddress { src: TackyVal, dst: TackyVal },
+    Load { src_ptr: TackyVal, dst: TackyVal },
+    Store { src: TackyVal, dst_ptr: TackyVal },
+    AddPtr { ptr: TackyVal, index: TackyVal, scale: usize, dst: TackyVal },
+    CopyToOffset { src: TackyVal, dst: String, offset: usize },
+    CopyFromOffset { src: String, offset: usize, dst: TackyVal },
+    Jump(String),
+    JumpIfZero(TackyVal, String),
+    JumpIfNotZero(TackyVal, String),
+    Label(String),
+    FunCall { f: String, args: Vec<TackyVal>, dst: Option<TackyVal> },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TopLevel {
+    Function { name: String, global: bool, params: Vec<String>, body: Vec<Instruction> },
+    StaticVariable { name: String, t: Type, global: bool, init: Vec<StaticInit> },
+    StaticConstant { name: String, t: Type, init: StaticInit },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Program(pub Vec<TopLevel>);


### PR DESCRIPTION
## Summary
- Add `initializers` Rust module modeling static data initializers
- Implement symbol table management in new `symbols` module
- Introduce `tacky` intermediate representation and link to constants
- Expose new modules and support `Const::type_of_const`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6896f94bb94883209b727adddd7a4163