### PR TITLE
Port settings and assembly stubs

### DIFF
--- a/rust/src/assembly.rs
+++ b/rust/src/assembly.rs
@@ -1,0 +1,126 @@
+use crate::initializers::StaticInit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Reg {
+    AX,
+    BX,
+    CX,
+    DX,
+    DI,
+    SI,
+    R8,
+    R9,
+    R10,
+    R11,
+    R12,
+    R13,
+    R14,
+    R15,
+    SP,
+    BP,
+    XMM0,
+    XMM1,
+    XMM2,
+    XMM3,
+    XMM4,
+    XMM5,
+    XMM6,
+    XMM7,
+    XMM8,
+    XMM9,
+    XMM10,
+    XMM11,
+    XMM12,
+    XMM13,
+    XMM14,
+    XMM15,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Operand {
+    Imm(i64),
+    Reg(Reg),
+    Pseudo(String),
+    Memory(Reg, i32),
+    Data(String, i32),
+    PseudoMem(String, i32),
+    Indexed { base: Reg, index: Reg, scale: i32 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOperator {
+    Neg,
+    Not,
+    Shr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    Add,
+    Sub,
+    Mult,
+    DivDouble,
+    And,
+    Or,
+    Xor,
+    Shl,
+    ShrBinop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CondCode {
+    E,
+    NE,
+    G,
+    GE,
+    L,
+    LE,
+    A,
+    AE,
+    B,
+    BE,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AsmType {
+    Byte,
+    Longword,
+    Quadword,
+    Double,
+    ByteArray { size: i32, alignment: i32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Instruction {
+    Mov(AsmType, Operand, Operand),
+    Movsx { src_type: AsmType, dst_type: AsmType, src: Operand, dst: Operand },
+    MovZeroExtend { src_type: AsmType, dst_type: AsmType, src: Operand, dst: Operand },
+    Lea(Operand, Operand),
+    Cvttsd2si(AsmType, Operand, Operand),
+    Cvtsi2sd(AsmType, Operand, Operand),
+    Unary(UnaryOperator, AsmType, Operand),
+    Binary { op: BinaryOperator, t: AsmType, src: Operand, dst: Operand },
+    Cmp(AsmType, Operand, Operand),
+    Idiv(AsmType, Operand),
+    Div(AsmType, Operand),
+    Cdq(AsmType),
+    Jmp(String),
+    JmpCC(CondCode, String),
+    SetCC(CondCode, Operand),
+    Label(String),
+    Push(Operand),
+    Pop(Reg),
+    Call(String),
+    Ret,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TopLevel {
+    Function { name: String, global: bool, instructions: Vec<Instruction> },
+    StaticVariable { name: String, alignment: i32, global: bool, init: Vec<StaticInit> },
+    StaticConstant { name: String, alignment: i32, init: StaticInit },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Program(pub Vec<TopLevel>);
+

--- a/rust/src/emit.rs
+++ b/rust/src/emit.rs
@@ -1,0 +1,9 @@
+use crate::assembly::Program;
+
+// Placeholder for future port of the OCaml emitter.
+// Currently this function simply exists so other modules can
+// link against it while the rest of the compiler is being ported.
+pub fn emit(_filename: &str, _program: Program) {
+    // TODO: implement assembly emission
+}
+

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,3 +17,7 @@ pub mod symbols;
 pub mod tacky;
 pub mod tacky_gen;
 pub mod tacky_print;
+pub mod settings;
+pub mod assembly;
+pub mod reg_set;
+pub mod emit;

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -16,6 +16,13 @@ pub mod private {
         }
     }
 
+    pub fn parse_id(ts: &mut TokenStream) -> Result<String> {
+        match ts.take_token() {
+            Some(Token::Identifier(id)) => Ok(id),
+            other => Err(ParseError(format!("expected identifier got {:?}", other))),
+        }
+    }
+
     pub fn parse_const(ts: &mut TokenStream) -> Result<Const> {
         match ts.take_token() {
             Some(Token::ConstInt(v)) => {
@@ -75,6 +82,7 @@ pub mod private {
 pub use private::parse_const;
 pub use private::parse_exp;
 pub use private::parse_statement;
+pub use private::parse_id;
 
 pub fn parse(tokens: Vec<Token>) -> Result<Program> {
     let mut ts = TokenStream::new(tokens);

--- a/rust/src/reg_set.rs
+++ b/rust/src/reg_set.rs
@@ -1,0 +1,5 @@
+use std::collections::BTreeSet;
+use crate::assembly::Reg;
+
+pub type RegSet = BTreeSet<Reg>;
+

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -1,0 +1,43 @@
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    Lex,
+    Parse,
+    Validate,
+    Tacky,
+    Codegen,
+    Assembly,
+    Obj,
+    Executable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    OSX,
+    Linux,
+}
+
+pub static PLATFORM: Lazy<Mutex<Platform>> = Lazy::new(|| Mutex::new(Platform::OSX));
+pub static DEBUG: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Optimizations {
+    pub constant_folding: bool,
+    pub dead_store_elimination: bool,
+    pub unreachable_code_elimination: bool,
+    pub copy_propagation: bool,
+}
+
+impl Default for Optimizations {
+    fn default() -> Self {
+        Self {
+            constant_folding: false,
+            dead_store_elimination: false,
+            unreachable_code_elimination: false,
+            copy_propagation: false,
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add configuration module mirroring OCaml settings
- introduce assembly types and register set utilities
- stub out assembly emitter and expose parse identifier helper

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896fd240ac08320bd0b47f98f631c49