### PR TITLE
Add Rust backend module stubs

### DIFF
--- a/rust/src/assembly_symbols.rs
+++ b/rust/src/assembly_symbols.rs
@@ -1,0 +1,169 @@
+use crate::assembly::{AsmType, Reg};
+use crate::reg_set::RegSet;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Entry {
+    Fun {
+        defined: bool,
+        bytes_required: i32,
+        return_on_stack: bool,
+        param_regs: Vec<Reg>,
+        return_regs: Vec<Reg>,
+        callee_saved_regs_used: RegSet,
+    },
+    Obj {
+        t: AsmType,
+        is_static: bool,
+        constant: bool,
+    },
+}
+
+static SYMBOL_TABLE: Lazy<Mutex<HashMap<String, Entry>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn add_fun(
+    fun_name: &str,
+    defined: bool,
+    return_on_stack: bool,
+    param_regs: Vec<Reg>,
+    return_regs: Vec<Reg>,
+) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        fun_name.into(),
+        Entry::Fun {
+            defined,
+            bytes_required: 0,
+            return_on_stack,
+            param_regs,
+            return_regs,
+            callee_saved_regs_used: RegSet::new(),
+        },
+    );
+}
+
+pub fn add_var(var_name: &str, t: AsmType, is_static: bool) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        var_name.into(),
+        Entry::Obj { t, is_static, constant: false },
+    );
+}
+
+pub fn add_constant(const_name: &str, t: AsmType) {
+    SYMBOL_TABLE.lock().unwrap().insert(
+        const_name.into(),
+        Entry::Obj { t, is_static: true, constant: true },
+    );
+}
+
+pub fn set_bytes_required(fun_name: &str, bytes_required: i32) {
+    let mut table = SYMBOL_TABLE.lock().unwrap();
+    if let Some(Entry::Fun { bytes_required: br, .. }) = table.get_mut(fun_name) {
+        *br = bytes_required;
+    } else {
+        panic!("Internal error: not a function");
+    }
+}
+
+pub fn get_bytes_required(fun_name: &str) -> i32 {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { bytes_required, .. }) => *bytes_required,
+        _ => panic!("Internal error: not a function"),
+    }
+}
+
+pub fn add_callee_saved_regs_used(fun_name: &str, regs: &RegSet) {
+    let mut table = SYMBOL_TABLE.lock().unwrap();
+    match table.get_mut(fun_name) {
+        Some(Entry::Fun { callee_saved_regs_used, .. }) => {
+            callee_saved_regs_used.extend(regs.iter().cloned());
+        }
+        _ => panic!("Internal error: not a function"),
+    }
+}
+
+pub fn get_callee_saved_regs_used(fun_name: &str) -> RegSet {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { callee_saved_regs_used, .. }) => callee_saved_regs_used.clone(),
+        _ => panic!("Internal error: not a function"),
+    }
+}
+
+pub fn get_type(name: &str) -> AsmType {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(name) {
+        Some(Entry::Obj { t, .. }) => t.clone(),
+        _ => panic!("Internal error: this is a function, not an object"),
+    }
+}
+
+pub fn get_size(name: &str) -> i32 {
+    match get_type(name) {
+        AsmType::Byte => 1,
+        AsmType::Longword => 4,
+        AsmType::Quadword | AsmType::Double => 8,
+        AsmType::ByteArray { size, .. } => size,
+    }
+}
+
+pub fn get_alignment(name: &str) -> i32 {
+    match get_type(name) {
+        AsmType::Byte => 1,
+        AsmType::Longword => 4,
+        AsmType::Quadword | AsmType::Double => 8,
+        AsmType::ByteArray { alignment, .. } => alignment,
+    }
+}
+
+pub fn is_defined(fun_name: &str) -> bool {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { defined, .. }) => *defined,
+        _ => panic!("Internal error: not a function"),
+    }
+}
+
+pub fn is_constant(name: &str) -> bool {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(name) {
+        Some(Entry::Obj { constant: true, .. }) => true,
+        Some(Entry::Obj { .. }) => false,
+        _ => panic!("Internal error: is_constant doesn't make sense for functions"),
+    }
+}
+
+pub fn is_static(name: &str) -> bool {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(name) {
+        Some(Entry::Obj { is_static, .. }) => *is_static,
+        _ => panic!("Internal error: functions don't have storage duration"),
+    }
+}
+
+pub fn returns_on_stack(fun_name: &str) -> bool {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { return_on_stack, .. }) => *return_on_stack,
+        _ => panic!("Internal error: this is an object, not a function"),
+    }
+}
+
+pub fn param_regs_used(fun_name: &str) -> Vec<Reg> {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { param_regs, .. }) => param_regs.clone(),
+        _ => panic!("Internal error: not a function"),
+    }
+}
+
+pub fn return_regs_used(fun_name: &str) -> Vec<Reg> {
+    let table = SYMBOL_TABLE.lock().unwrap();
+    match table.get(fun_name) {
+        Some(Entry::Fun { return_regs, .. }) => return_regs.clone(),
+        _ => panic!("Internal error: not a function"),
+    }
+}

--- a/rust/src/codegen.rs
+++ b/rust/src/codegen.rs
@@ -1,0 +1,8 @@
+use crate::assembly::Program as AsmProgram;
+use crate::tacky::Program as TackyProgram;
+
+/// Translate a TACKY program into assembly. Currently unimplemented in the
+/// Rust port.
+pub fn generate(_prog: TackyProgram) -> AsmProgram {
+    unimplemented!("code generation not yet ported")
+}

--- a/rust/src/instruction_fixup.rs
+++ b/rust/src/instruction_fixup.rs
@@ -1,0 +1,7 @@
+use crate::assembly::Program;
+
+/// Fix up invalid or unsupported assembly instructions. Stub implementation.
+pub fn fixup_program(prog: Program) -> Program {
+    // Actual instruction fixups are not yet ported.
+    prog
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,3 +25,8 @@ pub mod const_convert;
 pub mod cfg;
 pub mod backward_dataflow;
 pub mod compile;
+pub mod assembly_symbols;
+pub mod codegen;
+pub mod regalloc;
+pub mod replace_pseudos;
+pub mod instruction_fixup;

--- a/rust/src/regalloc.rs
+++ b/rust/src/regalloc.rs
@@ -1,0 +1,7 @@
+use std::collections::BTreeSet;
+use crate::assembly::Program;
+
+/// Allocate registers for the given assembly program. Stub implementation.
+pub fn allocate_registers(_aliased_vars: &BTreeSet<String>, _prog: Program) -> Program {
+    unimplemented!("register allocation not yet ported")
+}

--- a/rust/src/replace_pseudos.rs
+++ b/rust/src/replace_pseudos.rs
@@ -1,0 +1,119 @@
+use crate::assembly::{self, AsmType, Instruction, Operand, Reg, TopLevel, Program};
+use crate::assembly_symbols;
+use crate::rounding;
+use std::collections::BTreeMap;
+
+struct ReplacementState {
+    current_offset: i32,
+    offset_map: BTreeMap<String, i32>,
+}
+
+fn calculate_offset(state: &mut ReplacementState, name: &str) -> i32 {
+    let size = assembly_symbols::get_size(name);
+    let alignment = assembly_symbols::get_alignment(name);
+    state.current_offset = rounding::round_away_from_zero(alignment, state.current_offset - size);
+    state.offset_map.insert(name.into(), state.current_offset);
+    state.current_offset
+}
+
+fn replace_operand(state: &mut ReplacementState, op: Operand) -> Operand {
+    match op {
+        Operand::Pseudo(s) => {
+            if assembly_symbols::is_static(&s) {
+                Operand::Data(s, 0)
+            } else {
+                let offset = match state.offset_map.get(&s) {
+                    Some(off) => *off,
+                    None => calculate_offset(state, &s),
+                };
+                Operand::Memory(Reg::BP, offset)
+            }
+        }
+        Operand::PseudoMem(s, offset) => {
+            if assembly_symbols::is_static(&s) {
+                Operand::Data(s, offset)
+            } else {
+                let var_offset = match state.offset_map.get(&s) {
+                    Some(off) => *off,
+                    None => calculate_offset(state, &s),
+                };
+                Operand::Memory(Reg::BP, offset + var_offset)
+            }
+        }
+        other => other,
+    }
+}
+
+fn replace_pseudos_in_instruction(state: &mut ReplacementState, instr: Instruction) -> Instruction {
+    use Instruction::*;
+    match instr {
+        Mov(t, src, dst) => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Mov(t, src1, dst1)
+        }
+        Movsx { src_type, dst_type, src, dst } => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Movsx { src_type, dst_type, src: src1, dst: dst1 }
+        }
+        MovZeroExtend { src_type, dst_type, src, dst } => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            MovZeroExtend { src_type, dst_type, src: src1, dst: dst1 }
+        }
+        Lea(src, dst) => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Lea(src1, dst1)
+        }
+        Unary(op, t, dst) => {
+            let dst1 = replace_operand(state, dst);
+            Unary(op, t, dst1)
+        }
+        Binary { op, t, src, dst } => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Binary { op, t, src: src1, dst: dst1 }
+        }
+        Cmp(t, op1, op2) => {
+            let op1p = replace_operand(state, op1);
+            let op2p = replace_operand(state, op2);
+            Cmp(t, op1p, op2p)
+        }
+        Idiv(t, op) => Idiv(t, replace_operand(state, op)),
+        Div(t, op) => Div(t, replace_operand(state, op)),
+        SetCC(code, op) => SetCC(code, replace_operand(state, op)),
+        Push(op) => Push(replace_operand(state, op)),
+        Cvttsd2si(t, src, dst) => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Cvttsd2si(t, src1, dst1)
+        }
+        Cvtsi2sd(t, src, dst) => {
+            let src1 = replace_operand(state, src);
+            let dst1 = replace_operand(state, dst);
+            Cvtsi2sd(t, src1, dst1)
+        }
+        other @ (Ret | Cdq(_) | Label(_) | JmpCC(_, _) | Jmp(_) | Call(_)) => other,
+        Pop(_) => panic!("Internal error"),
+    }
+}
+
+fn replace_pseudos_in_tl(tl: TopLevel) -> TopLevel {
+    match tl {
+        TopLevel::Function { name, global, instructions } => {
+            let starting_offset = if assembly_symbols::returns_on_stack(&name) { -8 } else { 0 };
+            let mut state = ReplacementState { current_offset: starting_offset, offset_map: BTreeMap::new() };
+            let fixed_instructions: Vec<Instruction> =
+                instructions.into_iter().map(|i| replace_pseudos_in_instruction(&mut state, i)).collect();
+            assembly_symbols::set_bytes_required(&name, state.current_offset);
+            TopLevel::Function { name, global, instructions: fixed_instructions }
+        }
+        other => other,
+    }
+}
+
+pub fn replace_pseudos(Program(tls): Program) -> Program {
+    Program(tls.into_iter().map(replace_pseudos_in_tl).collect())
+}


### PR DESCRIPTION
## Summary
- port assembly symbol tracking to Rust
- translate pseudo register replacement to Rust
- scaffold backend codegen, regalloc, and instruction fixup modules

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68970105f9fc8320b80b17e4334e8185