### PR TITLE
Expand Rust AST structures

### DIFF
--- a/rust/src/ast.rs
+++ b/rust/src/ast.rs
@@ -1,25 +1,319 @@
-use std::fmt;
 use crate::consts::Const;
+use crate::types::Type;
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum Exp {
-    Constant(Const),
+pub mod ops {
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum UnaryOperator {
+        Complement,
+        Negate,
+        Not,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum BinaryOperator {
+        Add,
+        Subtract,
+        Multiply,
+        Divide,
+        Mod,
+        And,
+        Or,
+        Equal,
+        NotEqual,
+        LessThan,
+        LessOrEqual,
+        GreaterThan,
+        GreaterOrEqual,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Statement {
-    Return(Option<Exp>),
+pub enum StorageClass {
+    Static,
+    Extern,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Program;
-
-pub mod typed {
+pub mod untyped {
+    use super::StorageClass;
+    use super::ops::*;
+    use crate::consts::Const;
     use crate::types::Type;
 
     #[derive(Debug, Clone, PartialEq)]
-    pub struct Exp<T> {
-        pub e: T,
+    pub enum Exp {
+        Constant(Const),
+        Var(String),
+        String(String),
+        Cast {
+            target_type: Type,
+            e: Box<Exp>,
+        },
+        Unary(UnaryOperator, Box<Exp>),
+        Binary(BinaryOperator, Box<Exp>, Box<Exp>),
+        Assignment(Box<Exp>, Box<Exp>),
+        Conditional {
+            condition: Box<Exp>,
+            then_result: Box<Exp>,
+            else_result: Box<Exp>,
+        },
+        FunCall {
+            f: String,
+            args: Vec<Exp>,
+        },
+        Dereference(Box<Exp>),
+        AddrOf(Box<Exp>),
+        Subscript {
+            ptr: Box<Exp>,
+            index: Box<Exp>,
+        },
+        SizeOf(Box<Exp>),
+        SizeOfT(Type),
+        Dot {
+            strct: Box<Exp>,
+            member: String,
+        },
+        Arrow {
+            strct: Box<Exp>,
+            member: String,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Initializer {
+        SingleInit(Exp),
+        CompoundInit(Vec<Initializer>),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct MemberDeclaration {
+        pub member_name: String,
+        pub member_type: Type,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct StructDeclaration {
+        pub tag: String,
+        pub members: Vec<MemberDeclaration>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct VariableDeclaration {
+        pub name: String,
+        pub var_type: Type,
+        pub init: Option<Initializer>,
+        pub storage_class: Option<StorageClass>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum ForInit {
+        InitDecl(VariableDeclaration),
+        InitExp(Option<Exp>),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Statement {
+        Return(Option<Exp>),
+        Expression(Exp),
+        If {
+            condition: Exp,
+            then_clause: Box<Statement>,
+            else_clause: Option<Box<Statement>>,
+        },
+        Compound(Block),
+        Break(String),
+        Continue(String),
+        While {
+            condition: Exp,
+            body: Box<Statement>,
+            id: String,
+        },
+        DoWhile {
+            body: Box<Statement>,
+            condition: Exp,
+            id: String,
+        },
+        For {
+            init: ForInit,
+            condition: Option<Exp>,
+            post: Option<Exp>,
+            body: Box<Statement>,
+            id: String,
+        },
+        Null,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum BlockItem {
+        S(Statement),
+        D(Declaration),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Block(pub Vec<BlockItem>);
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FunctionDeclaration {
+        pub name: String,
+        pub fun_type: Type,
+        pub params: Vec<String>,
+        pub body: Option<Block>,
+        pub storage_class: Option<StorageClass>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Declaration {
+        FunDecl(FunctionDeclaration),
+        VarDecl(VariableDeclaration),
+        StructDecl(StructDeclaration),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Program(pub Vec<Declaration>);
+}
+
+pub mod typed {
+    use super::StorageClass;
+    use super::ops::*;
+    use crate::consts::Const;
+    use crate::types::Type;
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum InnerExp {
+        Constant(Const),
+        Var(String),
+        String(String),
+        Cast {
+            target_type: Type,
+            e: Box<Exp>,
+        },
+        Unary(UnaryOperator, Box<Exp>),
+        Binary(BinaryOperator, Box<Exp>, Box<Exp>),
+        Assignment(Box<Exp>, Box<Exp>),
+        Conditional {
+            condition: Box<Exp>,
+            then_result: Box<Exp>,
+            else_result: Box<Exp>,
+        },
+        FunCall {
+            f: String,
+            args: Vec<Exp>,
+        },
+        Dereference(Box<Exp>),
+        AddrOf(Box<Exp>),
+        Subscript {
+            ptr: Box<Exp>,
+            index: Box<Exp>,
+        },
+        SizeOf(Box<Exp>),
+        SizeOfT(Type),
+        Dot {
+            strct: Box<Exp>,
+            member: String,
+        },
+        Arrow {
+            strct: Box<Exp>,
+            member: String,
+        },
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Exp {
+        pub e: InnerExp,
         pub t: Type,
     }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Initializer {
+        SingleInit(Exp),
+        CompoundInit(Type, Vec<Initializer>),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct MemberDeclaration {
+        pub member_name: String,
+        pub member_type: Type,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct StructDeclaration {
+        pub tag: String,
+        pub members: Vec<MemberDeclaration>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct VariableDeclaration {
+        pub name: String,
+        pub var_type: Type,
+        pub init: Option<Initializer>,
+        pub storage_class: Option<StorageClass>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum ForInit {
+        InitDecl(VariableDeclaration),
+        InitExp(Option<Exp>),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Statement {
+        Return(Option<Exp>),
+        Expression(Exp),
+        If {
+            condition: Exp,
+            then_clause: Box<Statement>,
+            else_clause: Option<Box<Statement>>,
+        },
+        Compound(Block),
+        Break(String),
+        Continue(String),
+        While {
+            condition: Exp,
+            body: Box<Statement>,
+            id: String,
+        },
+        DoWhile {
+            body: Box<Statement>,
+            condition: Exp,
+            id: String,
+        },
+        For {
+            init: ForInit,
+            condition: Option<Exp>,
+            post: Option<Exp>,
+            body: Box<Statement>,
+            id: String,
+        },
+        Null,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum BlockItem {
+        S(Statement),
+        D(Declaration),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Block(pub Vec<BlockItem>);
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct FunctionDeclaration {
+        pub name: String,
+        pub fun_type: Type,
+        pub params: Vec<String>,
+        pub body: Option<Block>,
+        pub storage_class: Option<StorageClass>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Declaration {
+        FunDecl(FunctionDeclaration),
+        VarDecl(VariableDeclaration),
+        StructDecl(StructDeclaration),
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Program(pub Vec<Declaration>);
 }
+
+pub use ops::{BinaryOperator, UnaryOperator};
+pub use untyped::*;

--- a/rust/src/tacky_gen.rs
+++ b/rust/src/tacky_gen.rs
@@ -6,7 +6,7 @@ use crate::tacky::{self, Instruction, Program as TackyProgram, TackyVal, TopLeve
 fn emit_tacky_for_exp(e: &Exp) -> (Vec<Instruction>, TackyVal) {
     match e {
         Exp::Constant(c) => (vec![], TackyVal::Constant(c.clone())),
-        //_ => unimplemented!("expression translation not yet implemented"),
+        _ => unimplemented!("expression translation not yet implemented"),
     }
 }
 
@@ -19,6 +19,7 @@ fn emit_tacky_for_statement(stmt: &Statement) -> Vec<Instruction> {
             instrs.push(Instruction::Return(Some(val)));
             instrs
         }
+        _ => unimplemented!("statement translation not yet implemented"),
     }
 }
 
@@ -50,4 +51,3 @@ mod tests {
         }
     }
 }
-

--- a/rust/src/type_utils.rs
+++ b/rust/src/type_utils.rs
@@ -1,12 +1,12 @@
-use crate::ast::typed::Exp as TypedExp;
+use crate::ast::typed::{Exp as TypedExp, InnerExp};
 use crate::type_table;
 use crate::types::Type;
 
-pub fn get_type<T>(exp: &TypedExp<T>) -> Type {
+pub fn get_type(exp: &TypedExp) -> Type {
     exp.t.clone()
 }
 
-pub fn set_type<T>(e: T, new_type: Type) -> TypedExp<T> {
+pub fn set_type(e: InnerExp, new_type: Type) -> TypedExp {
     TypedExp { e, t: new_type }
 }
 
@@ -40,7 +40,11 @@ pub fn is_signed(t: &Type) -> bool {
     match t {
         Type::Int | Type::Long | Type::Char | Type::SChar => true,
         Type::UInt | Type::ULong | Type::Pointer(_) | Type::UChar => false,
-        Type::Double | Type::FunType { .. } | Type::Array { .. } | Type::Void | Type::Structure(_) => {
+        Type::Double
+        | Type::FunType { .. }
+        | Type::Array { .. }
+        | Type::Void
+        | Type::Structure(_) => {
             panic!(
                 "Internal error: signedness doesn't make sense for non-integral type {}",
                 t
@@ -56,13 +60,7 @@ pub fn is_pointer(t: &Type) -> bool {
 pub fn is_integer(t: &Type) -> bool {
     matches!(
         t,
-        Type::Char
-            | Type::UChar
-            | Type::SChar
-            | Type::Int
-            | Type::UInt
-            | Type::Long
-            | Type::ULong
+        Type::Char | Type::UChar | Type::SChar | Type::Int | Type::UInt | Type::Long | Type::ULong
     )
 }
 


### PR DESCRIPTION
## Summary
- Implement full Rust AST mirroring OCaml's `ast.ml`, including operators, expressions, statements, declarations and typed variants
- Update type utilities for new typed AST structure
- Stub out code generation to handle expanded AST

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68970344c16883208b2ef92ee20ad1ea