### PR TITLE
Polish Rust parser and compile modules

### DIFF
--- a/rust/src/compile.rs
+++ b/rust/src/compile.rs
@@ -1,29 +1,36 @@
 use crate::lex;
-use crate::parse;
+use crate::parse::{self, ParseError};
 use crate::settings::{Optimizations, Stage};
 use std::fs;
+
+/// Errors that can occur while compiling a source file.
+#[derive(Debug)]
+pub enum CompileError {
+    Io(std::io::Error),
+    Lex(String),
+    Parse(ParseError),
+}
 
 /// Compile a source file through the requested stage.
 ///
 /// The Rust port currently supports lexing and parsing stages. Later
 /// stages are stubs so that other modules can build on top of this
 /// interface.
-pub fn compile(stage: Stage, _optimizations: Optimizations, src_file: &str) {
-    let source = fs::read_to_string(src_file).expect("unable to read source file");
-    let tokens = match lex::lex(&source) {
-        Ok(t) => t,
-        Err(_) => return,
-    };
+pub fn compile(
+    stage: Stage,
+    _optimizations: Optimizations,
+    src_file: &str,
+) -> Result<(), CompileError> {
+    let source = fs::read_to_string(src_file).map_err(CompileError::Io)?;
+    let tokens = lex::lex(&source).map_err(CompileError::Lex)?;
     if stage == Stage::Lex {
-        return;
+        return Ok(());
     }
-    let ast = match parse::parse(tokens) {
-        Ok(prog) => prog,
-        Err(_) => return,
-    };
+    let ast = parse::parse(tokens).map_err(CompileError::Parse)?;
     if stage == Stage::Parse {
         println!("{:?}", ast);
-        return;
+        return Ok(());
     }
     // Further stages are not yet implemented in the Rust version.
+    Ok(())
 }

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -57,10 +57,6 @@ pub mod private {
         result
     }
 
-    fn is_ident(t: &Token) -> bool {
-        matches!(t, Token::Identifier(_))
-    }
-
     // specifiers
     fn is_type_specifier(t: &Token) -> bool {
         matches!(


### PR DESCRIPTION
## Summary
- remove unused identifier helper from the parser
- return structured errors from the compile interface

## Testing
- `cd rust && cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689708c51cd48320926b8f01453aec56